### PR TITLE
doc: fix url to fragments website

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is a demo app showing a very simple web fragment that consists of a single button which shoots confetti.
 
-The demo is deployed at https://party-button.demos.web-fragments.dev/ from where it can be embedded into other applications as a [Web Fragment](https://web-fragments.dev).
+The demo is deployed at https://party-button.demos.web-fragments.dev/ from where it can be embedded into other applications as a [Web Fragments](https://web-fragments.dev).
 
 
 


### PR DESCRIPTION
This pull request fixes a minor typo in the `README.md` file, updating the link to the correct "Web Fragments" website.